### PR TITLE
fix: move summary to trailing position to prevent silent truncation

### DIFF
--- a/lib/technocore.js
+++ b/lib/technocore.js
@@ -143,6 +143,11 @@ function noteField(value, name, nextNames) {
   return match ? match[1].trim() : "";
 }
 
+function trailingField(value, name) {
+  const match = String(value || "").match(new RegExp(`(?:^|\\s)${name}:(.*)`));
+  return match ? match[1].trim() : "";
+}
+
 function parseProfileNote(value) {
   const text = String(value || "");
   const mailbox = profileField(text, "mailbox");
@@ -159,7 +164,7 @@ function parseContributionNote(value) {
   const text = String(value || "");
   return {
     contributionType: profileField(text, "type"),
-    contributionSummary: noteField(text, "summary", ["url", "x"]),
+    contributionSummary: trailingField(text, "summary"),
     guideUrl: profileField(text, "url"),
     xHandle: profileField(text, "x").replace(/^@/, ""),
   };
@@ -276,9 +281,9 @@ function buildKit(input = {}) {
       `did:${did}`,
       `agent:${agentName}`,
       `type:${contribType}`,
-      `summary:${contributionSummary}`,
       guideUrl ? `url:${guideUrl}` : "",
       xHandle ? `x:@${xHandle}` : "",
+      `summary:${contributionSummary}`,
     ].filter(Boolean).join(" "),
     8192,
   );

--- a/test/technocore.test.js
+++ b/test/technocore.test.js
@@ -50,13 +50,37 @@ test("parses mailbox details from a DID profile note", () => {
 
 test("parses saved contribution details from a contribution note", () => {
   const contribution = parseContributionNote(
-    "technocore-contribution-v1 did:did:key:z6Mkxxx agent:demo_agent type:video summary:A simple video guide for beginners url:https://example.com/video x:@demo_user",
+    "technocore-contribution-v1 did:did:key:z6Mkxxx agent:demo_agent type:video url:https://example.com/video x:@demo_user summary:A simple video guide for beginners",
   );
 
   assert.equal(contribution.contributionType, "video");
   assert.equal(contribution.contributionSummary, "A simple video guide for beginners");
   assert.equal(contribution.guideUrl, "https://example.com/video");
   assert.equal(contribution.xHandle, "demo_user");
+});
+
+test("contribution summary containing field-like substrings is not truncated", () => {
+  // Regression: when summary was written before url/x in the note, a summary
+  // such as "check the url: docs" was silently truncated to "check the"
+  // because the parser treated "url:" as the start of the next field. Moving
+  // summary to the trailing position eliminates the ambiguity entirely.
+  const identity = createDid();
+  const tricky = "Read the api docs, check the url: field and the x: header before shipping.";
+  const kit = buildKit({
+    privateKeyJwk: identity.privateKeyJwk,
+    agentName: "test_agent",
+    contributionType: "guide",
+    contributionSummary: tricky,
+    guideUrl: "https://example.com/guide",
+    xHandle: "test_handle",
+    baseUrl: "https://technocore.chat",
+  });
+
+  const parsed = parseContributionNote(kit.contributionNote.value);
+  assert.equal(parsed.contributionSummary, tricky,
+    "summary must survive a round-trip even when it contains 'url:' or 'x:' substrings");
+  assert.equal(parsed.guideUrl, "https://example.com/guide");
+  assert.equal(parsed.xHandle, "test_handle");
 });
 
 test("signs canonical Technocore room messages", () => {


### PR DESCRIPTION
Bug: When a user's contribution summary contains substrings that look like field markers (url:, x:), parseContributionNote silently truncates the text at that point. For example, a summary like "Read the api docs, check the url: field carefully" is read back as just "Read the api docs, check the" — silent data loss with no error.

Root cause: summary was written before the url and x fields in the contribution note, so noteField's lookahead regex ((?=\s(?:url:|x:))) matched the user's own text instead of the actual next field boundary.

Fix: Move summary to the trailing (last) position in the serialized note, and read it back with a new trailingField parser that simply matches everything after summary: to end-of-string. No ambiguity, no lookahead, no truncation — regardless of what the user writes.

Tests: Added a regression test that round-trips a summary containing both url: and x: substrings through buildKit → parseContributionNote and verifies it survives intact. All 11 tests pass.